### PR TITLE
Add support for Pushover custom sounds

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -204,147 +204,37 @@
             "sound": {
               "title": "Sound",
               "type": "string",
-              "default": "pushover",
-              "oneOf": [
-                {
-                  "title": "pushover",
-                  "enum": [
-                    "pushover"
-                  ]
-                },
-                {
-                  "title": "bike",
-                  "enum": [
-                    "bike"
-                  ]
-                },
-                {
-                  "title": "bugle",
-                  "enum": [
-                    "bugle"
-                  ]
-                },
-                {
-                  "title": "cashregister",
-                  "enum": [
-                    "cashregister"
-                  ]
-                },
-                {
-                  "title": "classical",
-                  "enum": [
-                    "classical"
-                  ]
-                },
-                {
-                  "title": "cosmic",
-                  "enum": [
-                    "cosmic"
-                  ]
-                },
-                {
-                  "title": "falling",
-                  "enum": [
-                    "falling"
-                  ]
-                },
-                {
-                  "title": "gamelan",
-                  "enum": [
-                    "gamelan"
-                  ]
-                },
-                {
-                  "title": "incoming",
-                  "enum": [
-                    "incoming"
-                  ]
-                },
-                {
-                  "title": "intermission",
-                  "enum": [
-                    "intermission"
-                  ]
-                },
-                {
-                  "title": "magic",
-                  "enum": [
-                    "magic"
-                  ]
-                },
-                {
-                  "title": "mechanical",
-                  "enum": [
-                    "mechanical"
-                  ]
-                },
-                {
-                  "title": "pianobar",
-                  "enum": [
-                    "pianobar"
-                  ]
-                },
-                {
-                  "title": "siren",
-                  "enum": [
-                    "siren"
-                  ]
-                },
-                {
-                  "title": "spacealarm",
-                  "enum": [
-                    "spacealarm"
-                  ]
-                },
-                {
-                  "title": "tugboat",
-                  "enum": [
-                    "tugboat"
-                  ]
-                },
-                {
-                  "title": "alien",
-                  "enum": [
-                    "alien"
-                  ]
-                },
-                {
-                  "title": "climb",
-                  "enum": [
-                    "climb"
-                  ]
-                },
-                {
-                  "title": "persistent",
-                  "enum": [
-                    "persistent"
-                  ]
-                },
-                {
-                  "title": "echo",
-                  "enum": [
-                    "echo"
-                  ]
-                },
-                {
-                  "title": "updown",
-                  "enum": [
-                    "updown"
-                  ]
-                },
-                {
-                  "title": "vibrate",
-                  "enum": [
-                    "vibrate"
-                  ]
-                },
-                {
-                  "title": "none",
-                  "enum": [
-                    "none"
-                  ]
-                }
-              ]
+              "default": "",
+              "typeahead": {
+                "source": [
+                  "pushover",
+                  "bike",
+                  "bugle",
+                  "cashregister",
+                  "classical",
+                  "cosmic",
+                  "falling",
+                  "falling",
+                  "falling",
+                  "gamelan",
+                  "incoming",
+                  "intermission",
+                  "magic",
+                  "mechanical",
+                  "pianobar",
+                  "siren",
+                  "spacealarm",
+                  "tugboat",
+                  "alien",
+                  "climb",
+                  "persistent",
+                  "persistent",
+                  "echo",
+                  "updown",
+                  "vibrate",
+                  "none"
+                ]
+              }
             },
             "url": {
               "title": "Url",

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -36,9 +36,7 @@ module.exports = class PushOverMessenger {
         if (this.message_device)
             this.message_device = this.message_device.replace(/\s/g,'')
 
-        if (!["pushover", "bike", "bugle", "cashregister", "classical", "cosmic", "falling", "gamelan", 
-                "incoming", "intermission", "magic", "mechanical", "pianobar", "siren", "spacealarm", "tugboat", 
-                "alien", "climb", "persistent", "echo", "updown", "none"].includes(this.message_sound))
+        if (!this.message_sound)
             this.message_sound = "pushover";
     }
 


### PR DESCRIPTION
Implements issue #25: Simple change which allows custom sounds to be specified for Pushover messages.

This patch:
1.  Removes the check which prevented custom sounds from being specified in the JSON config; instead, uses supplied value, unless supplied value is empty, where it defaults to "pushover". 
2. Changes the `Sound` element in the UI from a dropdown to a "typeahead" text field which suggests values for the default sounds as the user types.

Nothing fancy. It won't provide a list of the user's custom sounds, but it shouldn't be too hard for a user to test out the switch to guard against typos.